### PR TITLE
Add branching rules for Google Jules in RULES.md

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -30,4 +30,6 @@ This document outlines the core principles and guidelines for developing within 
 
 ## 6. AI Assistant Preferences
 *   **Creating Tasks:** Whenever the user asks to "Add a task in the github task project" or similar phrasing, it strictly means to *both* add the task to the project *and* convert it into an issue.
+*   **Google Jules Branches:** If Jules needs to create a branch, always create it under `/jules/`.
+*   **Google Jules Branch Naming:** If the branch has a connecting task or issue, the branch name should start with `task#{task/issue number}`.
 


### PR DESCRIPTION
This PR updates the `RULES.md` file to include two new branching guidelines specifically for the AI assistant, Google Jules.

The added rules are:
1. Always create branches under the `/jules/` directory.
2. Prefix branch names with `task#{task/issue number}` if the branch is associated with a specific task or issue.

These rules were added under the existing section `6. AI Assistant Preferences`.

---
*PR created automatically by Jules for task [5117675473599799215](https://jules.google.com/task/5117675473599799215) started by @willwhui*